### PR TITLE
Add simple theme provider example

### DIFF
--- a/components/examples/README.md
+++ b/components/examples/README.md
@@ -1,0 +1,37 @@
+# Simple Theme Provider
+
+This example demonstrates a minimal CSS variable based theme switcher that can be copied into any Next.js application.
+
+## Usage
+
+1. Copy `simple-theme-provider.tsx` into your project.
+2. Define your theme values and wrap your app with `SimpleThemeProvider`.
+
+```tsx
+const themes = {
+  default: {
+    background: '#ffffff',
+    foreground: '#000000',
+    primary: '#2563eb',
+  },
+  dark: {
+    background: '#0f172a',
+    foreground: '#f1f5f9',
+    primary: '#3b82f6',
+  },
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <SimpleThemeProvider themes={themes} defaultTheme="default">
+          {children}
+        </SimpleThemeProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+Call `const { setTheme } = useSimpleTheme()` anywhere in your app to switch themes. Set `disabled` on the provider to turn off custom theming.

--- a/components/examples/simple-theme-provider.tsx
+++ b/components/examples/simple-theme-provider.tsx
@@ -1,0 +1,60 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+/**
+ * Basic theme switcher that relies on CSS variables.
+ * Pass an object of themes where each theme maps variable
+ * names (without the leading --) to CSS values.
+ */
+export type ThemeMap = Record<string, Record<string, string>>;
+
+interface ThemeProviderProps {
+  themes: ThemeMap;
+  defaultTheme: string;
+  disabled?: boolean;
+  children: React.ReactNode;
+}
+
+interface ThemeContextValue {
+  theme: string;
+  setTheme: (name: string) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function SimpleThemeProvider({
+  themes,
+  defaultTheme,
+  disabled = false,
+  children,
+}: ThemeProviderProps) {
+  const [theme, setTheme] = useState(defaultTheme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (!root) return;
+
+    // Remove any previously set variables
+    Object.keys(themes[theme] || {}).forEach((key) => {
+      root.style.removeProperty(`--${key}`);
+    });
+
+    if (disabled) return;
+
+    const styles = themes[theme];
+    if (!styles) return;
+
+    Object.entries(styles).forEach(([key, value]) => {
+      root.style.setProperty(`--${key}`, value);
+    });
+  }, [theme, disabled, themes]);
+
+  const value = { theme, setTheme };
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useSimpleTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useSimpleTheme must be used within SimpleThemeProvider");
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- provide a minimal plug & play CSS variable theme provider example
- document how to use the simple provider

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f8abb55a083338d6f62bf14927263